### PR TITLE
anchor#105 attaching .zip and .tar.gz to deployment; not automaticall…

### DIFF
--- a/.github/workflows/maven_master.yml
+++ b/.github/workflows/maven_master.yml
@@ -47,7 +47,12 @@ jobs:
     - name: Build with Maven
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: mvn --batch-mode --update-snapshots deploy
+        
+        # Do not deploy the final tar.gz and .zip distribution packages automatically, only addplugins
+        # The user can instead use the maven release plugin to deploy each properly versioned distribution
+        #   or manually deploy from the command-line for a snapshot
+      run: mvn --batch-mode --update-snapshots install
+      run: mvn --batch-mode -f addplugins/pom.xml deploy
       
   sonarcloud:
 

--- a/anchor/pom.xml
+++ b/anchor/pom.xml
@@ -182,7 +182,7 @@
               <descriptors>
                 <descriptor>src/assembly/distribution.xml</descriptor>
               </descriptors>
-              <attach>false</attach>
+              <attach>true</attach>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…y triggering deploy on master branch push, leaving it for the mvn release plugin to deploy.